### PR TITLE
Assume that empty and optional slices are valid

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -1233,8 +1233,13 @@ func typeCheck(v reflect.Value, t reflect.StructField, o reflect.Value, options 
 	}
 
 	// An optional and zero field should not be validated
-	if _, isOptional := options["optional"]; isOptional && v.IsZero() {
-		return true, nil
+	if _, isOptional := options["optional"]; isOptional {
+		if v.IsZero() {
+			return true, nil
+		}
+		if v.Kind() == reflect.Slice && v.Len() == 0 {
+			return true, nil
+		}
 	}
 
 	if !isFieldSet(v) {


### PR DESCRIPTION
```go
	type A struct {
		Opts []string `valid:"optional,ResponseOption.HashId~No matching records found for specified response option identifier."`
	}

	a := A{Opts: nil}               // is valid: true, slice is nil
	a = A{Opts: []string{"abc123"}} // is value: true, hash exists
	a = A{Opts: []string{"123abc"}} // is value: false, hash doesn't exists
	a = A{Opts: []string{}}         // error: invalid validator
```


after this change


```go
	type A struct {
		Opts []string `valid:"optional,ResponseOption.HashId~No matching records found for specified response option identifier."`
	}

	a := A{Opts: nil}               // is valid: true, slice is nil
	a = A{Opts: []string{"abc123"}} // is value: true, hash exists
	a = A{Opts: []string{"123abc"}} // is value: false, hash doesn't exists
	a = A{Opts: []string{}}         // is value: true, empty non-nil optional slice
``